### PR TITLE
Correct README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Install django-pwny::
 
     pip install django-pwny
 
-Add it to your `INSTALLED_APPS`:
+Add it to your `AUTH_PASSWORD_VALIDATORS`:
 
 .. code-block:: python
 


### PR DESCRIPTION
Replace mention of `INSTALLED_APPS` with `AUTH_PASSWORD_VALIDATORS`.

Fixes #1